### PR TITLE
Rolled back Microsoft.CodeAnalysis packages to include support for older version of VS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "Microsoft.CodeAnalysis"
+      - dependency-name: "Microsoft.CodeAnalysis.*"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+    <PropertyGroup>
+        <MicrosoftCodeAnalysisVersion>4.1.0</MicrosoftCodeAnalysisVersion>
+        <MicrosoftCodeAnalysisAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisAnalyzersVersion>
+        <MicrosoftCodeAnalysisCSharpCodeStyleVersion>4.1.0</MicrosoftCodeAnalysisCSharpCodeStyleVersion>
+    </PropertyGroup>
+</Project>

--- a/Selectorlyzer.Analyzers/Selectorlyzer.Analyzers.Test/Selectorlyzer.Analyzers.Test.csproj
+++ b/Selectorlyzer.Analyzers/Selectorlyzer.Analyzers.Test/Selectorlyzer.Analyzers.Test.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>    
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.Xunit" Version="1.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.Xunit" Version="1.1.1" />
   </ItemGroup>

--- a/Selectorlyzer.Analyzers/Selectorlyzer.Analyzers/Selectorlyzer.Analyzers.csproj
+++ b/Selectorlyzer.Analyzers/Selectorlyzer.Analyzers/Selectorlyzer.Analyzers.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Selectorlyzer.Analyzers/Selectorlyzer.Analyzers/SelectorlyzerDiagnosticAnalyzer.cs
+++ b/Selectorlyzer.Analyzers/Selectorlyzer.Analyzers/SelectorlyzerDiagnosticAnalyzer.cs
@@ -23,7 +23,7 @@ public class SelectorlyzerDiagnosticAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
 
         context.RegisterCompilationStartAction(CompilationStartAction);
@@ -67,7 +67,7 @@ public class SelectorlyzerDiagnosticAnalyzer : DiagnosticAnalyzer
         }
 
         var qulalySelector = QulalySelector.Parse(selector);
-        var analyzer = new Analyzer(qulalySelector, rule, message, severity, selectorlyzerRule.IncludeGeneratedCode);
+        var analyzer = new Analyzer(qulalySelector, rule, message, severity);
 
         if (qulalySelector.Selector is TypeSelector typeSelector)
         {
@@ -85,24 +85,17 @@ public class SelectorlyzerDiagnosticAnalyzer : DiagnosticAnalyzer
         private readonly string? rule;
         private readonly string message;
         private readonly string severity;
-        private readonly bool includeGeneratedCode;
 
-        public Analyzer(QulalySelector selector, string? rule, string message, string severity, bool includeGeneratedCode)
+        public Analyzer(QulalySelector selector, string? rule, string message, string severity)
         {
             this.selector = selector;
             this.rule = rule;
             this.message = message;
             this.severity = severity;
-            this.includeGeneratedCode = includeGeneratedCode;
         }
 
         public void SyntaxTreeAnalysisRule(SyntaxTreeAnalysisContext context)
         {
-            if (includeGeneratedCode && context.IsGeneratedCode)
-            {
-                return;
-            }
-
             foreach (var node in context.Tree.QuerySelectorAll(selector))
             {
                 if (CheckRule(rule, node))
@@ -117,11 +110,6 @@ public class SelectorlyzerDiagnosticAnalyzer : DiagnosticAnalyzer
 
         public void SyntaxNodeRule(SyntaxNodeAnalysisContext context)
         {
-            if (includeGeneratedCode && context.IsGeneratedCode)
-            {
-                return;
-            }
-
             var syntax = context.Node;
 
             var node = syntax?.QuerySelector(selector);           

--- a/Selectorlyzer.Analyzers/Selectorlyzer.Analyzers/SelectorlyzerRule.cs
+++ b/Selectorlyzer.Analyzers/Selectorlyzer.Analyzers/SelectorlyzerRule.cs
@@ -9,6 +9,4 @@ public class SelectorlyzerRule
     public string Message { get; set; } = null!;
 
     public string? Severity { get; set; }
-
-    public bool IncludeGeneratedCode { get; set; }
 }

--- a/Selectorlyzer.Analyzers/Selectorlyzer.Qulaly/Selectorlyzer.Qulaly.csproj
+++ b/Selectorlyzer.Analyzers/Selectorlyzer.Qulaly/Selectorlyzer.Qulaly.csproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpCodeStyleVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Added variables to control Microsoft.CodeAnalysis package versions
* Removed support for analyzing generated code which was only supported in the latest version of VS
* Disabled dependabot for Microsoft.CodeAnalysis packages